### PR TITLE
Implement Transfold CLI for OpenRouter translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,125 @@
-# translate_cli
+# Transfold
+
+Transfold is a command-line utility that recursively scans a directory tree, translates Markdown (or other text-based) files via the OpenRouter API, and writes the results back in-place or to a mirror output directory. The tool is designed for technical documentation workflows and keeps fenced code blocks, inline code and YAML front matter intact by default.
+
+## Features
+
+- Recursive discovery of files with configurable extensions, include and exclude patterns.
+- Chunk-aware translation pipeline that respects Markdown structure and API character limits.
+- Concurrent OpenRouter requests with exponential backoff and retry handling.
+- Atomic file writes with optional `.bak` backups when overwriting source files.
+- Persistent SQLite cache to avoid re-translating unchanged segments.
+- Optional glossary ingestion (JSON or CSV) to enforce domain terminology.
+- Dry-run mode for auditing which files and segments would be processed.
+- Configurable via CLI flags or a `transfold.config.{yaml,json,toml}` file.
+
+## Installation
+
+The project ships with a `pyproject.toml`. Install the CLI (and optional YAML support) with:
+
+```bash
+pip install .
+# or, for YAML configuration support
+pip install .[yaml]
+```
+
+Alternatively, run the module directly without installation:
+
+```bash
+python -m transfold.cli --help
+```
+
+## Usage
+
+```bash
+transfold \
+  --input ./docs \
+  --target-lang zh \
+  --ext md,txt \
+  --output ./docs_zh \
+  --concurrency 8
+```
+
+Key arguments:
+
+| Flag | Description |
+| ---- | ----------- |
+| `--input` | **Required.** Root directory to scan for files. |
+| `--target-lang` | **Required.** Output language code (e.g. `zh`, `en`). |
+| `--ext` | Comma-separated list of extensions (default `md`). |
+| `--output` | Optional output directory. If omitted, files are updated in place with `.bak` backups. |
+| `--source-lang` | Source language code or `auto` (default). |
+| `--model` | OpenRouter model identifier (default `openrouter/auto`). |
+| `--concurrency` | Number of in-flight OpenRouter requests (default derived from CPU count). |
+| `--max-chars` | Maximum characters per chunk before secondary splitting (default `4000`). |
+| `--translate-code` / `--no-translate-code` | Toggle translating fenced code blocks (default disabled). |
+| `--translate-frontmatter` / `--no-translate-frontmatter` | Toggle translating YAML front matter (default disabled). |
+| `--dry-run` | Report files and segment counts without contacting the API. |
+| `--cache-dir` | Override the cache directory (default `.transfold-cache`). |
+| `--glossary` | Path to JSON or CSV glossary mapping source terms to fixed translations. |
+| `--retry`, `--timeout` | Control retry attempts and per-request timeout. |
+
+Set the OpenRouter API key via the `OPENROUTER_API_KEY` environment variable (recommended) or pass `--api-key`. The key is never persisted to disk.
+
+### Include/Exclude Patterns
+
+Use `--include` / `--exclude` (repeatable) for glob-style pattern filtering relative to the input directory. For example:
+
+```bash
+transfold --input docs --target-lang zh --include "**/*.md" --exclude "**/node_modules/**"
+```
+
+### Dry Run
+
+`--dry-run` prints all candidate files and the number of translation segments without performing any API calls. This is useful for estimating workload or verifying pattern filters.
+
+### Glossary Support
+
+Provide a JSON object (`{"source": "translation"}`) or two-column CSV file to pin terminology. Glossary entries are appended to the system prompt for every translation request.
+
+## Configuration File
+
+Transfold automatically loads configuration from `transfold.config.yaml`, `.yml`, `.json` or `.toml` in the current working directory. CLI flags override config values.
+
+Example `transfold.config.yaml`:
+
+```yaml
+input: ./docs
+output: ./docs_zh
+ext: [md]
+target_lang: zh
+source_lang: auto
+model: openrouter/auto
+concurrency: 8
+include:
+  - "**/*.md"
+exclude:
+  - "**/node_modules/**"
+chunk:
+  strategy: markdown
+  max_chars: 4000
+preserve_code: true
+preserve_frontmatter: true
+retry: 3
+timeout: 60
+cache_dir: ./.transfold-cache
+backup: true
+```
+
+## Cache
+
+The cache lives in `.transfold-cache/segments.sqlite3` by default and stores per-chunk translations keyed by source content, target language and model. Delete the file to force re-translation.
+
+## Logging & Output
+
+During execution, Transfold displays a progress bar for translation segments, retry notifications, and a final summary with counts and (when provided by the API) token usage statistics. Failed files are listed at the end with their corresponding errors.
+
+## Development
+
+- Format and type-check using your preferred tools (no specific formatter enforced).
+- Run the CLI locally with `python -m transfold.cli --help`.
+- Contributions are welcome via pull requests.
+
+## License
+
+Distributed under the MIT License. See `LICENSE` for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "transfold"
+version = "0.1.0"
+description = "CLI tool to translate Markdown trees using the OpenRouter API"
+readme = "README.md"
+authors = [{name = "Transfold Contributors"}]
+license = {file = "LICENSE"}
+requires-python = ">=3.10"
+dependencies = [
+    "httpx>=0.24,<0.28",
+    "tqdm>=4.66",
+]
+
+[project.optional-dependencies]
+yaml = ["PyYAML>=6.0"]
+
+[project.scripts]
+transfold = "transfold.cli:main"

--- a/transfold/__init__.py
+++ b/transfold/__init__.py
@@ -1,0 +1,9 @@
+"""Transfold – translate Markdown trees with OpenRouter."""
+
+from __future__ import annotations
+
+__all__ = ["main", "__version__"]
+
+__version__ = "0.1.0"
+
+from .cli import main  # noqa: E402  (re-export for convenience)

--- a/transfold/__main__.py
+++ b/transfold/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/transfold/cache.py
+++ b/transfold/cache.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Optional
+
+
+class TranslationCache:
+    """A lightweight SQLite-backed cache for translated segments."""
+
+    def __init__(self, cache_dir: Path) -> None:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        self.path = cache_dir / "segments.sqlite3"
+        self._conn = sqlite3.connect(self.path)
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS translations (
+                cache_key TEXT PRIMARY KEY,
+                chunk_hash TEXT NOT NULL,
+                target_lang TEXT NOT NULL,
+                model TEXT NOT NULL,
+                translation TEXT NOT NULL,
+                metadata TEXT
+            )
+            """
+        )
+        self._conn.commit()
+        self._lock = threading.Lock()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def compute_chunk_hash(self, content: str) -> str:
+        return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+    def compute_cache_key(self, chunk_hash: str, target_lang: str, model: str) -> str:
+        base = f"{chunk_hash}:{target_lang}:{model}"
+        return hashlib.sha256(base.encode("utf-8")).hexdigest()
+
+    def get(
+        self, cache_key: str
+    ) -> Optional[str]:
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT translation FROM translations WHERE cache_key = ?", (cache_key,)
+            )
+            row = cur.fetchone()
+            return row[0] if row else None
+
+    def set(
+        self,
+        cache_key: str,
+        *,
+        chunk_hash: str,
+        target_lang: str,
+        model: str,
+        translation: str,
+        metadata: Optional[dict] = None,
+    ) -> None:
+        payload = json.dumps(metadata or {}) if metadata else None
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT OR REPLACE INTO translations
+                    (cache_key, chunk_hash, target_lang, model, translation, metadata)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (cache_key, chunk_hash, target_lang, model, translation, payload),
+            )
+            self._conn.commit()

--- a/transfold/chunking.py
+++ b/transfold/chunking.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional
+
+
+@dataclass
+class Segment:
+    """A slice of a document that may or may not require translation."""
+
+    index: int
+    content: str
+    translate: bool = True
+    kind: str = "text"
+    metadata: dict = field(default_factory=dict)
+    translation: Optional[str] = None
+
+    def output(self) -> str:
+        return self.translation if self.translation is not None else self.content
+
+
+@dataclass
+class SegmentedDocument:
+    segments: List[Segment]
+
+    def merge(self) -> str:
+        return "".join(segment.output() for segment in self.segments)
+
+
+_CODE_FENCE_RE = re.compile(r"^([`~]{3,})(.*)$")
+_SENTENCE_RE = re.compile(r".+?(?:[.!?。！？；;](?:\s|$)|$)", re.S)
+_PARAGRAPH_SPLIT_RE = re.compile(r"(\n\s*\n)")
+
+
+def segment_document(
+    text: str,
+    *,
+    strategy: str = "markdown",
+    max_chars: int = 4000,
+    preserve_code: bool = True,
+    preserve_frontmatter: bool = True,
+) -> SegmentedDocument:
+    if strategy != "markdown":
+        raise ValueError(f"Unsupported segmentation strategy: {strategy}")
+
+    segments: List[Segment] = []
+    index = 0
+    remaining = text
+
+    if preserve_frontmatter and remaining.startswith("---"):
+        front, rest = _split_front_matter(remaining)
+        if front is not None:
+            segments.append(
+                Segment(index=index, content=front, translate=False, kind="front_matter")
+            )
+            index += 1
+            remaining = rest
+
+    text_segments = _split_markdown_body(
+        remaining,
+        max_chars=max_chars,
+        preserve_code=preserve_code,
+    )
+    for seg in text_segments:
+        seg.index = index
+        index += 1
+        segments.append(seg)
+
+    return SegmentedDocument(segments)
+
+
+def _split_front_matter(text: str) -> tuple[Optional[str], str]:
+    lines = text.splitlines(keepends=True)
+    if not lines:
+        return None, text
+
+    if not lines[0].strip().startswith("---"):
+        return None, text
+
+    collected: List[str] = [lines[0]]
+    for idx in range(1, len(lines)):
+        collected.append(lines[idx])
+        if lines[idx].strip().startswith("---"):
+            # include the line following the closing delimiter if blank to preserve spacing
+            remainder = "".join(lines[idx + 1 :])
+            return "".join(collected), remainder
+    return None, text
+
+
+def _split_markdown_body(
+    text: str,
+    *,
+    max_chars: int,
+    preserve_code: bool,
+) -> List[Segment]:
+    lines = text.splitlines(keepends=True)
+    length = len(lines)
+    idx = 0
+    buffer: List[str] = []
+    segments: List[Segment] = []
+
+    def flush_buffer() -> None:
+        nonlocal buffer
+        if not buffer:
+            return
+        block = "".join(buffer)
+        for part in _enforce_max_chars(block, max_chars):
+            segments.append(Segment(index=-1, content=part, translate=True, kind="text"))
+        buffer = []
+
+    while idx < length:
+        line = lines[idx]
+        stripped = line.lstrip()
+        fence_match = _CODE_FENCE_RE.match(stripped)
+        if preserve_code and fence_match:
+            flush_buffer()
+            fence = fence_match.group(1)
+            code_lines = [line]
+            idx += 1
+            while idx < length:
+                code_lines.append(lines[idx])
+                closing = lines[idx].lstrip().startswith(fence)
+                idx += 1
+                if closing:
+                    break
+            segments.append(
+                Segment(
+                    index=-1,
+                    content="".join(code_lines),
+                    translate=False,
+                    kind="code",
+                )
+            )
+            continue
+
+        buffer.append(line)
+        idx += 1
+
+    flush_buffer()
+    return segments
+
+
+def _enforce_max_chars(text: str, max_chars: int) -> Iterable[str]:
+    if max_chars <= 0 or len(text) <= max_chars:
+        return [text]
+
+    parts: List[str] = []
+    tokens = _PARAGRAPH_SPLIT_RE.split(text)
+    current = ""
+
+    def append_current() -> None:
+        nonlocal current
+        if current:
+            parts.append(current)
+            current = ""
+
+    for token in tokens:
+        if not token:
+            continue
+        if len(token) > max_chars:
+            # Flush what we have so far before diving deeper.
+            append_current()
+            for sentence in _split_sentences(token):
+                if len(sentence) > max_chars:
+                    # Fallback: hard wrap.
+                    for chunk in _chunk_plain(sentence, max_chars):
+                        parts.append(chunk)
+                    continue
+                if len(current) + len(sentence) > max_chars:
+                    append_current()
+                current += sentence
+            append_current()
+            continue
+
+        if len(current) + len(token) > max_chars:
+            append_current()
+        current += token
+
+    append_current()
+    return parts
+
+
+def _split_sentences(text: str) -> Iterable[str]:
+    sentences = _SENTENCE_RE.findall(text)
+    return [s for s in sentences if s]
+
+
+def _chunk_plain(text: str, size: int) -> Iterable[str]:
+    return [text[i : i + size] for i in range(0, len(text), size)]

--- a/transfold/cli.py
+++ b/transfold/cli.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .cache import TranslationCache
+from .chunking import segment_document
+from .config import merge_config, load_config
+from .files import atomic_write, gather_files, read_glossary, read_text
+from .progress import tqdm
+from .translator import OpenRouterTranslator, TranslationError
+
+
+DEFAULT_MODEL = "openrouter/auto"
+DEFAULT_MAX_CHARS = 4000
+DEFAULT_TIMEOUT = 60.0
+DEFAULT_RETRY = 3
+
+
+@dataclass
+class Settings:
+    input_dir: Path
+    output_dir: Optional[Path]
+    extensions: List[str]
+    target_lang: str
+    source_lang: str
+    model: str
+    concurrency: int
+    include: List[str]
+    exclude: List[str]
+    max_chars: int
+    chunk_strategy: str
+    translate_code: bool
+    translate_frontmatter: bool
+    dry_run: bool
+    backup: bool
+    retry: int
+    timeout: float
+    cache_dir: Path
+    glossary: Optional[Path]
+    api_key: str
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Transfold – translate Markdown at scale using OpenRouter")
+    parser.add_argument("--config", help="Path to a configuration file", default=None)
+    parser.add_argument("--input", help="Input directory", default=None)
+    parser.add_argument("--output", help="Output directory (mirror structure)")
+    parser.add_argument("--ext", action="append", help="File extensions to include (comma separated)", default=None)
+    parser.add_argument("--target-lang", help="Target language code")
+    parser.add_argument("--source-lang", help="Source language code or 'auto'", default=None)
+    parser.add_argument("--model", help="OpenRouter model identifier", default=None)
+    parser.add_argument("--concurrency", type=int, help="Number of concurrent API calls", default=None)
+    parser.add_argument("--include", action="append", help="Glob pattern to explicitly include", default=None)
+    parser.add_argument("--exclude", action="append", help="Glob pattern to exclude", default=None)
+    parser.add_argument("--max-chars", type=int, help="Maximum characters per translation chunk", default=None)
+    parser.add_argument("--chunk-strategy", help="Chunking strategy", default=None)
+    parser.add_argument(
+        "--translate-code",
+        action=argparse.BooleanOptionalAction,
+        help="Translate fenced code blocks as well",
+        default=None,
+    )
+    parser.add_argument(
+        "--translate-frontmatter",
+        action=argparse.BooleanOptionalAction,
+        help="Translate YAML front matter",
+        default=None,
+    )
+    parser.add_argument("--dry-run", action="store_true", help="List files and segments without translating")
+    parser.add_argument("--no-backup", action="store_true", help="Do not create .bak files when overwriting input")
+    parser.add_argument("--overwrite", action="store_true", help="Alias for --no-backup")
+    parser.add_argument("--retry", type=int, help="Maximum retry attempts", default=None)
+    parser.add_argument("--timeout", type=float, help="API request timeout in seconds", default=None)
+    parser.add_argument("--cache-dir", help="Cache directory", default=None)
+    parser.add_argument("--glossary", help="Glossary file (JSON or CSV)", default=None)
+    parser.add_argument("--api-key", help="OpenRouter API key", default=None)
+    return parser
+
+
+def parse_arguments(argv: Optional[List[str]] = None) -> Settings:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    config_data = load_config(args.config)
+    explicit_false = {"translate_code", "translate_frontmatter"}
+    cli_overrides = {}
+    for key, value in vars(args).items():
+        if key == "config":
+            continue
+        if value is None:
+            continue
+        if value is False and key not in explicit_false:
+            continue
+        cli_overrides[key] = value
+    merged: Dict[str, object] = merge_config(config_data, cli_overrides)
+
+    input_dir = merged.get("input") or merged.get("input_dir") or args.input
+    if not input_dir:
+        parser.error("--input is required")
+    input_path = Path(input_dir).expanduser().resolve()
+
+    output_dir = merged.get("output")
+    output_path = Path(output_dir).expanduser().resolve() if output_dir else None
+
+    ext_value = merged.get("ext") or ["md"]
+    if isinstance(ext_value, str):
+        extensions = [item.strip() for item in ext_value.split(",") if item.strip()]
+    else:
+        extensions = []
+        for item in ext_value:  # type: ignore[assignment]
+            if isinstance(item, str):
+                extensions.extend([part.strip() for part in item.split(",") if part.strip()])
+    if not extensions:
+        extensions = ["md"]
+
+    target_lang = (merged.get("target_lang") or merged.get("target-lang") or args.target_lang)
+    if not target_lang:
+        parser.error("--target-lang is required")
+
+    source_lang = (merged.get("source_lang") or merged.get("source-lang") or args.source_lang or "auto")
+    model = merged.get("model") or DEFAULT_MODEL
+
+    concurrency = merged.get("concurrency")
+    if concurrency is None:
+        concurrency = min(8, max(2, os.cpu_count() or 4))
+    concurrency = int(concurrency)
+
+    include = _ensure_list(merged.get("include"))
+    exclude = _ensure_list(merged.get("exclude"))
+
+    chunk_config = merged.get("chunk") if isinstance(merged.get("chunk"), dict) else {}
+    max_chars = int(
+        merged.get("max_chars")
+        or merged.get("max-chars")
+        or (chunk_config or {}).get("max_chars")
+        or (chunk_config or {}).get("max-chars")
+        or DEFAULT_MAX_CHARS
+    )
+    chunk_strategy = (
+        merged.get("chunk_strategy")
+        or merged.get("chunk-strategy")
+        or (chunk_config or {}).get("strategy")
+        or "markdown"
+    )
+
+    translate_code = _resolve_bool(
+        merged.get("translate_code"),
+        merged.get("translate-code"),
+        (chunk_config or {}).get("translate_code"),
+        (chunk_config or {}).get("translate-code"),
+        default=False,
+    )
+    translate_frontmatter = _resolve_bool(
+        merged.get("translate_frontmatter"),
+        merged.get("translate-frontmatter"),
+        (chunk_config or {}).get("translate_frontmatter"),
+        (chunk_config or {}).get("translate-frontmatter"),
+        default=False,
+    )
+
+    dry_run = bool(merged.get("dry_run") or merged.get("dry-run") or args.dry_run)
+    backup = _resolve_bool(
+        merged.get("backup"),
+        merged.get("preserve_backup"),
+        default=True,
+    )
+    backup = backup and not (
+        merged.get("no_backup")
+        or merged.get("no-backup")
+        or args.no_backup
+        or args.overwrite
+    )
+
+    retry = int(merged.get("retry") or DEFAULT_RETRY)
+    timeout = float(merged.get("timeout") or DEFAULT_TIMEOUT)
+
+    cache_dir = Path(merged.get("cache_dir") or merged.get("cache-dir") or ".transfold-cache").expanduser()
+
+    glossary_path = merged.get("glossary")
+    glossary = Path(glossary_path).expanduser() if glossary_path else None
+
+    api_key = (
+        merged.get("api_key")
+        or merged.get("api-key")
+        or args.api_key
+        or os.environ.get("OPENROUTER_API_KEY")
+    )
+    if not api_key:
+        parser.error("OpenRouter API key is required via --api-key or OPENROUTER_API_KEY")
+
+    return Settings(
+        input_dir=input_path,
+        output_dir=output_path,
+        extensions=extensions,
+        target_lang=str(target_lang),
+        source_lang=str(source_lang),
+        model=str(model),
+        concurrency=concurrency,
+        include=include,
+        exclude=exclude,
+        max_chars=max_chars,
+        chunk_strategy=str(chunk_strategy),
+        translate_code=bool(translate_code),
+        translate_frontmatter=bool(translate_frontmatter),
+        dry_run=dry_run,
+        backup=backup,
+        retry=retry,
+        timeout=timeout,
+        cache_dir=cache_dir,
+        glossary=glossary,
+        api_key=str(api_key),
+    )
+
+
+def _ensure_list(value: object) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        result: List[str] = []
+        for item in value:
+            if isinstance(item, str):
+                result.extend([part.strip() for part in item.split(",") if part.strip()])
+        return result
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    return []
+
+
+def _resolve_bool(*values: object, default: bool = False) -> bool:
+    for value in values:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            lowered = value.lower()
+            if lowered in {"true", "1", "yes", "on"}:
+                return True
+            if lowered in {"false", "0", "no", "off"}:
+                return False
+    return default
+
+
+def run(settings: Settings) -> int:
+    start = time.time()
+    if not settings.input_dir.is_dir():
+        print(f"Input directory {settings.input_dir} does not exist", file=sys.stderr)
+        return 1
+
+    files = list(
+        gather_files(
+            settings.input_dir,
+            extensions=settings.extensions,
+            include=settings.include,
+            exclude=settings.exclude,
+        )
+    )
+    if not files:
+        print("No files matched the provided criteria.")
+        return 0
+
+    documents = []
+    total_segments = 0
+    errors: List[str] = []
+
+    for file_path in files:
+        try:
+            text = read_text(file_path)
+        except Exception as exc:
+            errors.append(f"{file_path}: {exc}")
+            continue
+        segmented = segment_document(
+            text,
+            strategy=settings.chunk_strategy,
+            max_chars=settings.max_chars,
+            preserve_code=not settings.translate_code,
+            preserve_frontmatter=not settings.translate_frontmatter,
+        )
+        translatable = sum(1 for seg in segmented.segments if seg.translate and seg.content.strip())
+        total_segments += translatable
+        documents.append((file_path, text, segmented))
+
+    if settings.dry_run:
+        for file_path, _, segmented in documents:
+            translatable = sum(1 for seg in segmented.segments if seg.translate and seg.content.strip())
+            print(f"[DRY RUN] {file_path.relative_to(settings.input_dir)} -> {translatable} segments")
+        print(f"Total files: {len(documents)}, segments requiring translation: {total_segments}")
+        if errors:
+            print()
+            print("Skipped files due to errors:")
+            for item in errors:
+                print(f" - {item}")
+            return 1
+        return 0
+
+    glossary = None
+    if settings.glossary:
+        try:
+            glossary = read_glossary(settings.glossary)
+        except Exception as exc:
+            errors.append(f"Failed to read glossary: {exc}")
+
+    cache = TranslationCache(settings.cache_dir)
+    progress = (
+        tqdm(total=total_segments, unit="segment", desc="Translating")
+        if total_segments
+        else None
+    )
+
+    def on_progress(count: int) -> None:
+        if count and progress is not None:
+            progress.update(count)
+
+    async def on_retry(attempt: int, exc: Exception, delay: float) -> None:
+        message = f"Retry attempt {attempt} after error: {exc}. Waiting {delay:.1f}s"
+        if progress is not None:
+            progress.write(message)
+        else:
+            print(message)
+
+    try:
+        translator = OpenRouterTranslator(
+            api_key=settings.api_key,
+            model=settings.model,
+            target_lang=settings.target_lang,
+            source_lang=settings.source_lang,
+            timeout=settings.timeout,
+            retry=settings.retry,
+            concurrency=settings.concurrency,
+            cache=cache,
+            glossary=glossary,
+            progress_callback=on_progress,
+            retry_callback=on_retry,
+        )
+    except Exception as exc:
+        if progress is not None:
+            progress.close()
+        cache.close()
+        print(f"Failed to initialise translator: {exc}", file=sys.stderr)
+        return 1
+
+    async def process() -> None:
+        for file_path, original, segmented in documents:
+            try:
+                await translator.translate_segments(segmented.segments)
+            except TranslationError as exc:
+                errors.append(f"{file_path}: {exc}")
+                continue
+            rendered = segmented.merge()
+            destination = _resolve_output_path(settings, file_path)
+            if destination == file_path:
+                backup = settings.backup
+            else:
+                backup = False
+            if rendered == original:
+                continue
+            atomic_write(destination, rendered, backup=backup)
+
+    try:
+        asyncio.run(process())
+    finally:
+        asyncio.run(translator.close())
+        cache.close()
+        if progress is not None:
+            progress.close()
+
+    duration = time.time() - start
+    print()
+    print("Summary")
+    print("=======")
+    print(f"Files processed: {len(documents)}")
+    print(f"Segments translated: {translator.stats.total_segments}")
+    print(f"Segments served from cache: {translator.stats.cached_segments}")
+    print(f"API calls: {translator.stats.api_calls}")
+    print(f"Retries performed: {translator.stats.retries}")
+    if translator.stats.prompt_tokens or translator.stats.completion_tokens:
+        print(
+            "Token usage: prompt="
+            f"{translator.stats.prompt_tokens}, completion={translator.stats.completion_tokens}"
+        )
+    print(f"Elapsed time: {duration:.2f}s")
+
+    if errors:
+        print()
+        print("Failures:")
+        for item in errors:
+            print(f" - {item}")
+        return 1
+    return 0
+
+
+def _resolve_output_path(settings: Settings, path: Path) -> Path:
+    if settings.output_dir:
+        rel = path.relative_to(settings.input_dir)
+        return settings.output_dir / rel
+    return path
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    settings = parse_arguments(argv)
+    return run(settings)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/transfold/config.py
+++ b/transfold/config.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+try:  # pragma: no cover - optional dependency
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11 fallback
+    tomllib = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    yaml = None  # type: ignore
+
+
+DEFAULT_CONFIG_FILENAMES: tuple[str, ...] = (
+    "transfold.config.yaml",
+    "transfold.config.yml",
+    "transfold.config.json",
+    "transfold.config.toml",
+)
+
+
+class ConfigError(RuntimeError):
+    """Raised when a configuration file cannot be parsed."""
+
+
+def _candidate_paths(explicit: Optional[str]) -> Iterable[Path]:
+    if explicit:
+        yield Path(explicit)
+        return
+
+    cwd = Path.cwd()
+    for name in DEFAULT_CONFIG_FILENAMES:
+        candidate = cwd / name
+        if candidate.exists():
+            yield candidate
+            return
+
+
+def load_config(path: Optional[str]) -> Dict[str, Any]:
+    """Load configuration from a file if one exists.
+
+    Parameters
+    ----------
+    path:
+        The explicit path passed via CLI. When ``None`` the default file names are
+        probed in the current working directory.
+    """
+
+    for candidate in _candidate_paths(path):
+        if not candidate.exists():
+            continue
+        text = candidate.read_text(encoding="utf-8")
+        suffix = candidate.suffix.lower()
+        try:
+            if suffix in {".yaml", ".yml"}:
+                if yaml is None:
+                    raise ConfigError(
+                        "PyYAML is required to read YAML configuration files"
+                    )
+                data = yaml.safe_load(text) or {}
+            elif suffix == ".json":
+                data = json.loads(text or "{}")
+            elif suffix == ".toml":
+                if tomllib is None:
+                    raise ConfigError(
+                        "tomllib is unavailable; use Python 3.11+ for TOML configs"
+                    )
+                data = tomllib.loads(text or "")
+            else:
+                raise ConfigError(f"Unsupported config format: {candidate.suffix}")
+        except (json.JSONDecodeError, ValueError) as exc:  # pragma: no cover - parse errors
+            raise ConfigError(f"Failed to parse {candidate}: {exc}") from exc
+
+        if not isinstance(data, dict):
+            raise ConfigError("The configuration root must be a mapping/dictionary")
+
+        return data
+    return {}
+
+
+def merge_config(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge two dictionaries recursively without mutating the inputs."""
+
+    result: Dict[str, Any] = dict(base)
+    for key, value in override.items():
+        if (
+            key in result
+            and isinstance(result[key], dict)
+            and isinstance(value, dict)
+        ):
+            result[key] = merge_config(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def env_default(key: str, default: Optional[str] = None) -> Optional[str]:
+    """Retrieve a configuration default from the environment."""
+
+    return os.environ.get(key, default)

--- a/transfold/files.py
+++ b/transfold/files.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Iterable, Iterator, Sequence
+
+
+class FileReadError(RuntimeError):
+    pass
+
+
+def gather_files(
+    root: Path,
+    *,
+    extensions: Sequence[str],
+    include: Sequence[str] | None = None,
+    exclude: Sequence[str] | None = None,
+) -> Iterator[Path]:
+    include_patterns = list(include or [])
+    exclude_patterns = list(exclude or [])
+    normalized_exts = {
+        ext.lower().lstrip(".") for ext in extensions if ext
+    } or set()
+
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if normalized_exts:
+            suffix = path.suffix.lower().lstrip(".")
+            if suffix not in normalized_exts:
+                continue
+        rel = path.relative_to(root).as_posix()
+        if include_patterns and not any(fnmatch(rel, pattern) for pattern in include_patterns):
+            continue
+        if exclude_patterns and any(fnmatch(rel, pattern) for pattern in exclude_patterns):
+            continue
+        yield path
+
+
+def read_text(path: Path) -> str:
+    try:
+        data = path.read_bytes()
+    except OSError as exc:  # pragma: no cover - depends on filesystem
+        raise FileReadError(f"Failed to read {path}: {exc}") from exc
+    if b"\0" in data:
+        raise FileReadError(f"{path} appears to be a binary file; skipping")
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise FileReadError(f"{path} is not valid UTF-8: {exc}") from exc
+
+
+def ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def atomic_write(
+    path: Path,
+    content: str,
+    *,
+    backup: bool = False,
+    encoding: str = "utf-8",
+) -> None:
+    ensure_parent(path)
+    tmp_fd, tmp_path = tempfile.mkstemp(prefix=path.name, dir=path.parent)
+    try:
+        with os.fdopen(tmp_fd, "w", encoding=encoding, newline="") as handle:
+            handle.write(content)
+        if backup and path.exists():
+            backup_path = path.with_suffix(path.suffix + ".bak")
+            shutil.copy2(path, backup_path)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def read_glossary(path: Path) -> dict[str, str]:
+    suffix = path.suffix.lower()
+    if suffix in {".json"}:
+        import json
+
+        return json.loads(path.read_text(encoding="utf-8"))
+    if suffix in {".csv"}:
+        import csv
+
+        mapping: dict[str, str] = {}
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            reader = csv.reader(handle)
+            for row in reader:
+                if len(row) >= 2:
+                    mapping[row[0].strip()] = row[1].strip()
+        return mapping
+    raise ValueError(f"Unsupported glossary format: {path.suffix}")

--- a/transfold/progress.py
+++ b/transfold/progress.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any
+
+try:  # pragma: no cover - optional dependency handling
+    from tqdm import tqdm as _tqdm  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+
+    class _TqdmFallback:
+        def __init__(self, total: int | None = None, unit: str | None = None, desc: str | None = None, **_: Any) -> None:
+            self.total = total
+            self.unit = unit
+            self.desc = desc
+
+        def update(self, _n: int) -> None:
+            return None
+
+        def write(self, message: str) -> None:
+            print(message)
+
+        def close(self) -> None:
+            return None
+
+    def tqdm(*args: Any, **kwargs: Any) -> _TqdmFallback:
+        return _TqdmFallback(*args, **kwargs)
+
+else:  # pragma: no cover - thin wrapper
+
+    def tqdm(*args: Any, **kwargs: Any):  # type: ignore[misc]
+        return _tqdm(*args, **kwargs)

--- a/transfold/translator.py
+++ b/transfold/translator.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import asyncio
+import random
+import textwrap
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Iterable, List, Optional
+
+try:  # pragma: no cover - optional dependency
+    import httpx  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - provide friendly error later
+    httpx = None  # type: ignore
+
+from .cache import TranslationCache
+from .chunking import Segment
+
+
+class TranslationError(RuntimeError):
+    pass
+
+
+@dataclass
+class TranslatorStats:
+    total_segments: int = 0
+    cached_segments: int = 0
+    api_calls: int = 0
+    retries: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+
+RetryCallback = Callable[[int, Exception, float], Awaitable[None]]
+ProgressCallback = Callable[[int], None]
+
+
+class OpenRouterTranslator:
+    endpoint = "https://openrouter.ai/api/v1/chat/completions"
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str,
+        target_lang: str,
+        source_lang: str = "auto",
+        timeout: float = 60.0,
+        retry: int = 3,
+        concurrency: int = 4,
+        cache: Optional[TranslationCache] = None,
+        glossary: Optional[dict[str, str]] = None,
+        progress_callback: Optional[ProgressCallback] = None,
+        retry_callback: Optional[RetryCallback] = None,
+        system_prompt: Optional[str] = None,
+    ) -> None:
+        self.api_key = api_key
+        self.model = model
+        self.target_lang = target_lang
+        self.source_lang = source_lang
+        self.timeout = timeout
+        self.retry = retry
+        self.cache = cache
+        self.glossary = glossary or {}
+        self.progress_callback = progress_callback
+        self.retry_callback = retry_callback
+        self.system_prompt = system_prompt or self._default_system_prompt()
+        if httpx is None:
+            raise RuntimeError(
+                "httpx is required to use the OpenRouter translator. Install transfold with its dependencies."
+            )
+        self._client = httpx.AsyncClient(timeout=timeout)
+        self._semaphore = asyncio.Semaphore(max(1, concurrency))
+        self.stats = TranslatorStats()
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def translate_segments(self, segments: List[Segment]) -> None:
+        tasks: List[asyncio.Task[None]] = []
+        for segment in segments:
+            if not segment.translate or not segment.content.strip():
+                segment.translation = segment.content
+                if self.progress_callback:
+                    self.progress_callback(1)
+                continue
+            self.stats.total_segments += 1
+            chunk_hash = self.cache.compute_chunk_hash(segment.content) if self.cache else None
+            cache_key = (
+                self.cache.compute_cache_key(chunk_hash, self.target_lang, self.model)
+                if self.cache and chunk_hash is not None
+                else None
+            )
+            if cache_key and self.cache:
+                cached = self.cache.get(cache_key)
+                if cached is not None:
+                    segment.translation = cached
+                    self.stats.cached_segments += 1
+                    if self.progress_callback:
+                        self.progress_callback(1)
+                    continue
+
+            task = asyncio.create_task(
+                self._translate_segment(segment, chunk_hash, cache_key)
+            )
+            tasks.append(task)
+
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    async def _translate_segment(
+        self,
+        segment: Segment,
+        chunk_hash: Optional[str],
+        cache_key: Optional[str],
+    ) -> None:
+        last_error: Optional[Exception] = None
+        for attempt in range(1, self.retry + 1):
+            try:
+                async with self._semaphore:
+                    translation, usage = await self._request(segment.content)
+                segment.translation = translation
+                if cache_key and self.cache and chunk_hash:
+                    self.cache.set(
+                        cache_key,
+                        chunk_hash=chunk_hash,
+                        target_lang=self.target_lang,
+                        model=self.model,
+                        translation=translation,
+                        metadata={"source_lang": self.source_lang},
+                    )
+                if usage:
+                    self.stats.prompt_tokens += usage.get("prompt_tokens", 0)
+                    self.stats.completion_tokens += usage.get("completion_tokens", 0)
+                self.stats.api_calls += 1
+                if self.progress_callback:
+                    self.progress_callback(1)
+                return
+            except Exception as exc:  # broad catch to honour retry semantics
+                last_error = exc
+                if attempt >= self.retry:
+                    break
+                self.stats.retries += 1
+                delay = min(30.0, 2 ** (attempt - 1))
+                # jitter between 0.1 and 0.5 seconds to avoid thundering herd
+                jitter = random.uniform(0.1, 0.5)
+                if self.retry_callback:
+                    await self.retry_callback(attempt, exc, delay + jitter)
+                await asyncio.sleep(delay + jitter)
+        raise TranslationError(str(last_error) if last_error else "Unknown error")
+
+    async def _request(self, text: str) -> tuple[str, Optional[dict]]:
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        payload = {
+            "model": self.model,
+            "temperature": 0,
+            "messages": [
+                {"role": "system", "content": self.system_prompt},
+                {"role": "user", "content": self._user_prompt(text)},
+            ],
+        }
+        response = await self._client.post(self.endpoint, json=payload, headers=headers)
+        if response.status_code >= 500 or response.status_code == 429:
+            raise httpx.HTTPStatusError(
+                f"Server error: {response.status_code} {response.text}", request=response.request, response=response
+            )
+        if response.status_code != 200:
+            raise TranslationError(
+                f"OpenRouter API returned status {response.status_code}: {response.text}"
+            )
+        data = response.json()
+        try:
+            message = data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError) as exc:  # pragma: no cover - depends on API
+            raise TranslationError("Unexpected response format from OpenRouter API") from exc
+        usage = data.get("usage") if isinstance(data, dict) else None
+        return message.strip(), usage
+
+    def _default_system_prompt(self) -> str:
+        glossary_text = ""
+        if self.glossary:
+            items = "\n".join(f"- {src} -> {dst}" for src, dst in self.glossary.items())
+            glossary_text = "\nGlossary (use these translations verbatim):\n" + items
+        return textwrap.dedent(
+            f"""
+            You are a professional technical documentation translator.
+            Translate all provided text into {self.target_lang} while preserving Markdown structure and formatting.
+            Do not translate fenced code blocks, inline code spans, URLs, or image paths.
+            Do not add commentary or explanations; respond with the translated text only.{glossary_text}
+            """
+        ).strip()
+
+    def _user_prompt(self, text: str) -> str:
+        source_line = (
+            f"The source language is {self.source_lang}." if self.source_lang != "auto" else "Detect the source language automatically."
+        )
+        return textwrap.dedent(
+            f"""
+            {source_line}
+            The target language is {self.target_lang}.
+            Translate the following content. Return only the translated text without wrapping quotes.
+            ---
+            {text}
+            ---
+            """
+        ).strip()


### PR DESCRIPTION
## Summary
- add the `transfold` Python package providing a CLI for translating Markdown/document trees through the OpenRouter API
- support configuration files, glossary ingestion, chunked Markdown segmentation, caching, and atomic output handling
- document installation and usage details in the README and ship a `pyproject.toml` with dependencies

## Testing
- python -m transfold.cli --help
- python -m transfold.cli --input . --target-lang zh --dry-run --ext md --api-key test --include README.md
- python -m compileall transfold

------
https://chatgpt.com/codex/tasks/task_e_68ce280c65888321bd7c6a784dab2198