### PR TITLE
Fix job duration timer and widen job detail layout

### DIFF
--- a/web/frontend/src/styles.css
+++ b/web/frontend/src/styles.css
@@ -150,6 +150,10 @@ button {
   gap: 32px;
 }
 
+.page--wide {
+  max-width: none;
+}
+
 .surface {
   background: var(--surface);
   border: 1px solid var(--border-color);


### PR DESCRIPTION
## Summary
- anchor the job duration timer to server timestamps so the running clock reflects real execution time
- stretch the job detail layout by adding a wide page modifier so content can fill the viewport

## Testing
- npm run build *(fails: unable to download npm packages in this environment, registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d005ddcc5883219a45df3478bde008