### PR TITLE
Fix preview tree directory expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,18 @@ translate_cli 提供面向单条文本的命令行翻译工具，而 Transfold �
 
 ```bash
 # 后端（默认读取 .env，监听 8000 端口）
-uvicorn web.backend.app:app --reload
+python -m web.backend
 
 # 前端（在 web/frontend 下）
 cd web/frontend
 npm install
 npm run dev
 ```
+
+> **提示**：`python -m web.backend` 会在开发模式下自动启用热重载，但仅监控
+> `web/backend` 源码目录，同时忽略 `DATA_ROOT` 下的仓库与译文输出，避免出
+> 现 `OS file watch limit reached` 报错。若需关闭热重载，可设置
+> `UVICORN_RELOAD=0` 后再执行上述命令。
 
 开发环境默认将 `/api` 请求代理到 `http://localhost:8000`。`DATA_ROOT` 用于指定仓库克隆、译文输出和日志存储位置，可在 `.env` 中覆盖。
 

--- a/web/backend/__main__.py
+++ b/web/backend/__main__.py
@@ -1,0 +1,75 @@
+"""Convenience entry point for running the FastAPI backend in development.
+
+The stock ``uvicorn`` command watches the entire project tree when ``--reload``
+is enabled.  Our translation jobs clone Git repositories and persist outputs
+under ``DATA_ROOT`` (defaults to ``var/transfold``), which can easily contain
+thousands of files.  Watching those directories exhausts the inotify limit on
+Linux and crashes the dev server.
+
+This module wraps :func:`uvicorn.run` so we can opt in to autoreload while only
+tracking the backend source directory.  We also explicitly exclude the data
+directories derived from :class:`~web.backend.settings.AppSettings`, avoiding
+the file-watch explosion that previously occurred.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+import uvicorn
+
+from .settings import AppSettings
+
+
+def _to_unique_strings(paths: Iterable[Path]) -> List[str]:
+    """Return a list of unique, resolved string paths."""
+
+    unique: List[Path] = []
+    for path in paths:
+        resolved = path.resolve()
+        if resolved not in unique:
+            unique.append(resolved)
+    return [str(item) for item in unique]
+
+
+def _should_reload(flag: str | None) -> bool:
+    if flag is None:
+        return True
+    lowered = flag.strip().lower()
+    return lowered not in {"0", "false", "no", "off"}
+
+
+def main() -> None:
+    """Start the FastAPI application with sensible dev defaults."""
+
+    settings = AppSettings.load()
+
+    backend_dir = Path(__file__).resolve().parent
+    reload_dirs: Sequence[Path] = (backend_dir,)
+
+    # Ignore dynamically populated directories that can contain thousands of
+    # files (cloned repos, translation outputs, logs, databases...).
+    reload_excludes: Sequence[Path] = (
+        settings.data_root,
+        settings.repos_root,
+        settings.outputs_root,
+        settings.logs_root,
+        settings.history_db.parent,
+        settings.cache_db.parent,
+    )
+
+    uvicorn.run(  # pragma: no cover - thin wrapper around uvicorn
+        "web.backend.app:app",
+        host=os.getenv("UVICORN_HOST", "127.0.0.1"),
+        port=int(os.getenv("UVICORN_PORT", "8000")),
+        reload=_should_reload(os.getenv("UVICORN_RELOAD")),
+        reload_dirs=_to_unique_strings(reload_dirs),
+        reload_excludes=_to_unique_strings(reload_excludes),
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -131,6 +131,25 @@ export function formatEta(seconds?: number | null): string {
   return `${minutes} 分 ${remaining} 秒`;
 }
 
+const TZ_SUFFIX_REGEX = /(Z|[+-]\d\d:\d\d)$/;
+
+export function parseTimestamp(value?: string | null): number | null {
+  if (!value) return null;
+  const normalized = TZ_SUFFIX_REGEX.test(value) ? value : `${value}Z`;
+  const parsed = Date.parse(normalized);
+  if (Number.isNaN(parsed)) {
+    const fallback = Date.parse(value);
+    return Number.isNaN(fallback) ? null : fallback;
+  }
+  return parsed;
+}
+
+export function formatTimestamp(value?: string | null): string {
+  const timestamp = parseTimestamp(value);
+  if (timestamp === null) return "--";
+  return new Date(timestamp).toLocaleString();
+}
+
 export function formatDuration(seconds?: number | null): string {
   if (seconds === undefined || seconds === null) return "--";
   const totalSeconds = Math.max(0, Math.floor(seconds));

--- a/web/frontend/src/pages/HistoryPage.tsx
+++ b/web/frontend/src/pages/HistoryPage.tsx
@@ -50,7 +50,7 @@ function HistoryPage() {
   };
 
   return (
-    <div className="page">
+    <div className="page page--wide">
       <section className="surface">
         <h2 className="section-title">任务历史</h2>
         <form onSubmit={handleSearch} className="history-search">

--- a/web/frontend/src/pages/PreviewPage.tsx
+++ b/web/frontend/src/pages/PreviewPage.tsx
@@ -30,7 +30,8 @@ function buildTree(entries: TreeEntry[]): TreeNode {
       currentPath = currentPath ? `${currentPath}/${part}` : part;
       const isLast = index === parts.length - 1;
       const nodeKey = currentPath;
-      if (!dirMap[nodeKey]) {
+      const existing = dirMap[nodeKey];
+      if (!existing) {
         const node: TreeNode = {
           name: part,
           path: nodeKey,
@@ -42,15 +43,10 @@ function buildTree(entries: TreeEntry[]): TreeNode {
         }
         if (node.type === "directory") {
           dirMap[nodeKey] = node;
-        }
-        if (!isLast) {
-          current = dirMap[nodeKey];
+          current = node;
         }
       } else {
-        current = dirMap[nodeKey];
-      }
-      if (isLast && entry.type === "file") {
-        current.type = "file";
+        current = existing;
       }
     });
   });
@@ -176,37 +172,39 @@ function PreviewPage() {
   }
 
   return (
-    <div className="preview-root">
-      <aside className="preview-nav">
-        <div className="preview-nav__header">
-          <span className="preview-nav__title">FILES</span>
-          <Link to={`/jobs/${id}`} className="preview-nav__link">返回任务</Link>
-        </div>
-        {error && <p className="preview-nav__error">{error}</p>}
-        {entries.length === 0 ? (
-          <p className="preview-nav__placeholder">暂无译文，请等待任务完成。</p>
-        ) : (
-          <TreeView node={tree} onSelect={setSelected} active={selected} />
-        )}
-      </aside>
-      <main className="preview-main">
-        <header className="preview-main__toolbar">
-          <span className="preview-main__filename">{selected || "选择一个文件"}</span>
-          <div className="preview-tabs">
-            {(["preview", "code", "raw"] as PreviewTab[]).map((item) => (
-              <button
-                key={item}
-                type="button"
-                className={`preview-tab${tab === item ? " is-active" : ""}`}
-                onClick={() => setTab(item)}
-              >
-                {item === "preview" ? "Preview" : item === "code" ? "Code" : "Raw"}
-              </button>
-            ))}
+    <div className="page page--wide">
+      <div className="preview-root">
+        <aside className="preview-nav">
+          <div className="preview-nav__header">
+            <span className="preview-nav__title">FILES</span>
+            <Link to={`/jobs/${id}`} className="preview-nav__link">返回任务</Link>
           </div>
-        </header>
-        <section className="preview-panel">{renderPreview()}</section>
-      </main>
+          {error && <p className="preview-nav__error">{error}</p>}
+          {entries.length === 0 ? (
+            <p className="preview-nav__placeholder">暂无译文，请等待任务完成。</p>
+          ) : (
+            <TreeView node={tree} onSelect={setSelected} active={selected} />
+          )}
+        </aside>
+        <main className="preview-main">
+          <header className="preview-main__toolbar">
+            <span className="preview-main__filename">{selected || "选择一个文件"}</span>
+            <div className="preview-tabs">
+              {(["preview", "code", "raw"] as PreviewTab[]).map((item) => (
+                <button
+                  key={item}
+                  type="button"
+                  className={`preview-tab${tab === item ? " is-active" : ""}`}
+                  onClick={() => setTab(item)}
+                >
+                  {item === "preview" ? "Preview" : item === "code" ? "Code" : "Raw"}
+                </button>
+              ))}
+            </div>
+          </header>
+          <section className="preview-panel">{renderPreview()}</section>
+        </main>
+      </div>
     </div>
   );
 }

--- a/web/frontend/src/pages/SubmitJobPage.tsx
+++ b/web/frontend/src/pages/SubmitJobPage.tsx
@@ -56,7 +56,7 @@ function SubmitJobPage() {
   };
 
   return (
-    <div className="page">
+    <div className="page page--wide">
       <section className="surface">
         <h2 className="section-title">提交新的翻译任务</h2>
       <form onSubmit={handleSubmit} className="form-grid">

--- a/web/frontend/src/styles.css
+++ b/web/frontend/src/styles.css
@@ -150,6 +150,10 @@ button {
   gap: 32px;
 }
 
+.page--wide {
+  max-width: none;
+}
+
 .surface {
   background: var(--surface);
   border: 1px solid var(--border-color);
@@ -446,7 +450,8 @@ textarea:focus {
 .preview-root {
   display: grid;
   grid-template-columns: clamp(220px, 22vw, 280px) minmax(0, 1fr);
-  width: min(1400px, 100%);
+  width: 100%;
+  max-width: none;
   border: 1px solid var(--border-color);
   border-radius: 18px;
   overflow: hidden;
@@ -501,20 +506,41 @@ textarea:focus {
   font-size: 14px;
 }
 
+.preview-tree .preview-tree {
+  padding-left: 16px;
+}
+
 .preview-tree__node details {
   color: var(--text-muted);
 }
 
-.preview-tree__node details > summary {
+.preview-tree__folder {
   list-style: none;
   cursor: pointer;
   font-weight: 600;
   color: var(--text-secondary);
   margin-bottom: 4px;
+  position: relative;
+  padding-left: 18px;
 }
 
-.preview-tree__node details > summary::-webkit-details-marker {
+.preview-tree__folder::-webkit-details-marker {
   display: none;
+}
+
+.preview-tree__folder::before {
+  content: "\25B8";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 10px;
+  transition: transform 0.2s ease;
+  color: var(--text-muted);
+}
+
+.preview-tree__node details[open] > .preview-tree__folder::before {
+  transform: translateY(-50%) rotate(90deg);
 }
 
 .preview-tree__item {


### PR DESCRIPTION
## Summary
- keep directory nodes typed correctly when building the preview tree so nested folders expand normally
- add indentation and chevron indicators to the preview sidebar for clearer folder hierarchies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d005ddcc5883219a45df3478bde008